### PR TITLE
5 seconds delay after shoulder validation

### DIFF
--- a/scripts/body_points_detector.py
+++ b/scripts/body_points_detector.py
@@ -10,6 +10,7 @@ from coco_interfaces.msg import BodyPoints
 from geometry_msgs.msg import Point32
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
+import time
 
 fig = plt.figure()
 ax = fig.add_subplot(111, projection="3d")
@@ -51,6 +52,9 @@ class BodyPointsDetectorNode(Node):
         self.subscription = self.create_subscription(
             Image, 'image_raw', self.image_callback, 10)
         self.publisher = self.create_publisher(BodyPoints, 'body_points', 10)
+
+        self.was_centered = False
+        self.centered_time = None
 
     def image_callback(self, msg):
         frame = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
@@ -107,14 +111,31 @@ class BodyPointsDetectorNode(Node):
             r2 = img_landmarks[mp_pose.PoseLandmark.RIGHT_SHOULDER]
             min_x, max_x = min(l2.x, r2.x), max(l2.x, r2.x)
 
-            if min_x < 0.3 or max_x > 0.7:
+            centered = not (min_x < 0.3 or max_x > 0.7)
+
+            if not centered:
+                if self.was_centered:
+                    self.get_logger().info('Persona fuera de centro, reiniciando timer de centrado.')
+                self.was_centered = False
+                self.centered_time = None
                 self.get_logger().info(
-                    f"Off-center image (x-range={min_x:.2f} to {max_x:.2f}), skipping BodyPoints")
+                    f"Off-center image (x-range={min_x:.2f}–{max_x:.2f}), skipping BodyPoints")
                 return
 
-            
+            if not self.was_centered:
+                current = time.time()
+                if self.centered_time is None:
+                    self.centered_time = current
+                    self.get_logger().info('Centrado detectado. Esperando 5 segundos antes de publicar.')
+                    return
+                elif (current - self.centered_time) < 5.0:
+                    return
+                else:
+                    self.was_centered = True
+                    self.centered_time = None
+
             self.publisher.publish(points_msg)
-            
+
 def main(args=None):
     rclpy.init(args=args)
     node = BodyPointsDetectorNode()

--- a/scripts/body_points_detector.py
+++ b/scripts/body_points_detector.py
@@ -55,6 +55,7 @@ class BodyPointsDetectorNode(Node):
 
         self.was_centered = False
         self.centered_time = None
+        self.max_waiting_time=5.0
 
     def image_callback(self, msg):
         frame = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
@@ -111,9 +112,9 @@ class BodyPointsDetectorNode(Node):
             r2 = img_landmarks[mp_pose.PoseLandmark.RIGHT_SHOULDER]
             min_x, max_x = min(l2.x, r2.x), max(l2.x, r2.x)
 
-            centered = not (min_x < 0.3 or max_x > 0.7)
+            outside_center = min_x < 0.3 or max_x > 0.7
 
-            if not centered:
+            if outside_center:
                 if self.was_centered:
                     self.get_logger().info('Persona fuera de centro, reiniciando timer de centrado.')
                 self.was_centered = False
@@ -128,7 +129,7 @@ class BodyPointsDetectorNode(Node):
                     self.centered_time = current
                     self.get_logger().info('Centrado detectado. Esperando 5 segundos antes de publicar.')
                     return
-                elif (current - self.centered_time) < 5.0:
+                elif (current-self.centered_time)<self.max_waiting_time:
                     return
                 else:
                     self.was_centered = True


### PR DESCRIPTION
## Abstract
In addition to the shoulder distance validation, now the project presents a delay of 5 seconds since the state changes from non-centered to centered. It's important to mention that this delay will not activate in every validation of the centered state, but it will detect only the change of the state from false to true. 

## Results
- [x] In the file named body_points_detector.py, an extra validation was added to it. It waits for being shoulder -centered in order to apply a 5 seconds delay and begin to publish the angles to the robot.

## Images
![Sin título3](https://github.com/user-attachments/assets/f9b635d9-93c6-4a9e-aa66-bd9b96602e1f)
|:--:|
| *Image 1 – Person out of range detection* |
![Sin título4](https://github.com/user-attachments/assets/0eb95c07-4b14-43e2-8a2d-4ed84c8d3f95)
| *Image 2 – Waiting for pose replication if centered.* |
![Sin título5](https://github.com/user-attachments/assets/d0363ca6-13bb-477e-80ec-5f76960c9bf1)
| *Image 3 – Detecting and publishing angles.* |




